### PR TITLE
chore: rename resource module to domain

### DIFF
--- a/apps/resource_manager/lib/credentials/passwords.ex
+++ b/apps/resource_manager/lib/credentials/passwords.ex
@@ -1,5 +1,5 @@
 defmodule ResourceManager.Credentials.Passwords do
   @moduledoc false
 
-  use ResourceManager.Resource, schema_model: ResourceManager.Credentials.Schemas.Password
+  use ResourceManager.Domain, schema_model: ResourceManager.Credentials.Schemas.Password
 end

--- a/apps/resource_manager/lib/credentials/public_keys.ex
+++ b/apps/resource_manager/lib/credentials/public_keys.ex
@@ -1,5 +1,5 @@
 defmodule ResourceManager.Credentials.PublicKeys do
   @moduledoc false
 
-  use ResourceManager.Resource, schema_model: ResourceManager.Credentials.Schemas.PublicKey
+  use ResourceManager.Domain, schema_model: ResourceManager.Credentials.Schemas.PublicKey
 end

--- a/apps/resource_manager/lib/domain.ex
+++ b/apps/resource_manager/lib/domain.ex
@@ -1,4 +1,4 @@
-defmodule ResourceManager.Resource do
+defmodule ResourceManager.Domain do
   @moduledoc """
   Implements helpfull functions to be used in resource domains.
   """

--- a/apps/resource_manager/lib/identity/client_applications.ex
+++ b/apps/resource_manager/lib/identity/client_applications.ex
@@ -1,5 +1,5 @@
 defmodule ResourceManager.Identity.ClientApplications do
   @moduledoc false
 
-  use ResourceManager.Resource, schema_model: ResourceManager.Identity.Schemas.ClientApplication
+  use ResourceManager.Domain, schema_model: ResourceManager.Identity.Schemas.ClientApplication
 end

--- a/apps/resource_manager/lib/identity/users.ex
+++ b/apps/resource_manager/lib/identity/users.ex
@@ -1,5 +1,5 @@
 defmodule ResourceManager.Identity.Users do
   @moduledoc false
 
-  use ResourceManager.Resource, schema_model: ResourceManager.Identity.Schemas.User
+  use ResourceManager.Domain, schema_model: ResourceManager.Identity.Schemas.User
 end

--- a/apps/resource_manager/lib/permissions/scopes.ex
+++ b/apps/resource_manager/lib/permissions/scopes.ex
@@ -1,5 +1,5 @@
 defmodule ResourceManager.Permissions.Scopes do
   @moduledoc false
 
-  use ResourceManager.Resource, schema_model: ResourceManager.Permissions.Schemas.Scope
+  use ResourceManager.Domain, schema_model: ResourceManager.Permissions.Schemas.Scope
 end


### PR DESCRIPTION
Just rename the `ResourceManager.Resource` to `Resource.Domain` because not any module that implesments these functions are resources.