### PR TITLE
feat: add endpoint for generating the authorization code

### DIFF
--- a/apps/authenticator/lib/sign_in/commands/authorization_code.ex
+++ b/apps/authenticator/lib/sign_in/commands/authorization_code.ex
@@ -21,6 +21,7 @@ defmodule Authenticator.SignIn.Commands.AuthorizationCode do
   }
 
   alias Authenticator.SignIn.Commands.Inputs.AuthorizationCode, as: Input
+  alias ResourceManager.Identities.Commands.Inputs.GetUser, as: User
 
   @behaviour Authenticator.SignIn.Commands.Behaviour
 
@@ -41,7 +42,7 @@ defmodule Authenticator.SignIn.Commands.AuthorizationCode do
          {:token, {:ok, claims}} <- {:token, AuthorizationCode.verify_and_validate(token)},
          {:same_client?, true} <- {:same_client?, client_id == claims["aud"]},
          {:same_redirect?, true} <- {:same_redirect?, claims["redirect_uri"] == redirect_uri},
-         {:user, {:ok, user}, _} <- {:user, Port.get_identity(%{id: claims["sub"]}), claims},
+         {:user, {:ok, user}, _} <- {:user, Port.get_identity(%User{id: claims["sub"]}), claims},
          {:user_active?, true, _} <- {:user_active?, user.status == "active", claims},
          {:public?, true, _} <- {:public?, public_app?(app), {user, app, input, claims}} do
       geretate_tokens_and_parse_response(user, app, claims)

--- a/apps/authorizer/.formatter.exs
+++ b/apps/authorizer/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:ecto, :ecto_sql],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/apps/authorizer/lib/authorizer.ex
+++ b/apps/authorizer/lib/authorizer.ex
@@ -3,11 +3,16 @@ defmodule Authorizer do
   Application to deal with request's to authorization server.
   """
 
-  alias Authorizer.Rules.Commands.{AdminAccess, PublicAccess}
+  alias Authorizer.Rules.Commands.{AdminAccess, AuthorizationCodeSignIn, PublicAccess}
 
   @doc "Delegates to #{AdminAccess}.execute/1"
   defdelegate authorize_admin(conn), to: AdminAccess, as: :execute
 
   @doc "Delegates to #{PublicAccess}.execute/1"
   defdelegate authorize_public(conn), to: PublicAccess, as: :execute
+
+  @doc "Delegates to #{AuthorizationCodeSignIn}.execute/1"
+  defdelegate authorize_authorization_code_sign_in(input, user_id),
+    to: AuthorizationCodeSignIn,
+    as: :execute
 end

--- a/apps/authorizer/lib/input.ex
+++ b/apps/authorizer/lib/input.ex
@@ -1,0 +1,60 @@
+defmodule Authorizer.Input do
+  @moduledoc """
+  Implements helpfull functions to be used in inputs
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      use Ecto.Schema
+
+      import Ecto.Changeset
+
+      alias Ecto.Changeset
+
+      @primary_key false
+      @foreign_key_type false
+
+      @doc "Validates the given parameters and cast into #{__MODULE__} struct"
+      @spec cast_and_apply(params :: map()) :: {:ok, __MODULE__.t()} | {:error, Changeset.t()}
+      def cast_and_apply(params) when is_map(params) do
+        params
+        |> __MODULE__.changeset()
+        |> case do
+          %{valid?: true} = changeset -> {:ok, Changeset.apply_changes(changeset)}
+          %{valid?: false} = changeset -> {:error, changeset}
+        end
+      end
+
+      @doc "Cast #{__MODULE__} to a list"
+      @spec cast_to_list(input :: __MODULE__.t()) :: list()
+      def cast_to_list(%{__struct__: __MODULE__} = input) do
+        input
+        |> cast_to_map()
+        |> Map.to_list()
+        |> Enum.filter(fn {_key, value} -> not is_nil(value) end)
+      end
+
+      @doc "Cast #{__MODULE__} to an atom map"
+      @spec cast_to_map(input :: __MODULE__.t()) :: map()
+      def cast_to_map(%{__struct__: __MODULE__} = input) do
+        input
+        |> Map.from_struct()
+        |> Map.new(&do_cast_to_map/1)
+      end
+
+      defp do_cast_to_map(%Date{} = value), do: value
+      defp do_cast_to_map(%DateTime{} = value), do: value
+      defp do_cast_to_map(%NaiveDateTime{} = value), do: value
+      defp do_cast_to_map(%Time{} = value), do: value
+      defp do_cast_to_map([_ | _] = list), do: Enum.map(list, &do_cast_to_map/1)
+
+      defp do_cast_to_map(%_struct{} = struct) do
+        struct
+        |> Map.from_struct()
+        |> Map.new(&do_cast_to_map/1)
+      end
+
+      defp do_cast_to_map(value), do: value
+    end
+  end
+end

--- a/apps/authorizer/lib/rules/commands/authorization_code_sign_in.ex
+++ b/apps/authorizer/lib/rules/commands/authorization_code_sign_in.ex
@@ -91,8 +91,7 @@ defmodule Authorizer.Rules.Commands.AuthorizationCodeSignIn do
 
     scopes
     |> Scopes.convert_to_list()
-    |> Enum.filter(&(&1 in app_scopes))
-    |> Enum.filter(&(&1 in user_scopes))
+    |> Enum.filter(&(&1 in app_scopes or &1 in user_scopes))
     |> Scopes.convert_to_string()
     |> case do
       "" -> nil

--- a/apps/authorizer/lib/rules/commands/authorization_code_sign_in.ex
+++ b/apps/authorizer/lib/rules/commands/authorization_code_sign_in.ex
@@ -1,0 +1,114 @@
+defmodule Authorizer.Rules.Commands.AuthorizationCodeSignIn do
+  @moduledoc """
+  Rule for authorizing a subject sign in on authorization code flow.
+  """
+
+  alias Authenticator.Sessions.Tokens.AuthorizationCode
+  alias Authorizer.Ports.ResourceManager, as: Port
+  alias Authorizer.Rules.Commands.Inputs.AuthorizationCodeSignIn, as: Input
+  alias ResourceManager.Identities.Commands.Inputs.GetUser
+  alias ResourceManager.Permissions.Scopes
+
+  require Logger
+
+  @typedoc "Authorization code success map response"
+  @type success_map :: %{
+          authorization_code: String.t(),
+          expires_in: pos_integer(),
+          token_type: String.t()
+        }
+
+  @doc """
+  Run the authorization flow in order to verify if the subject matches all requirements.
+
+  In order to authorize we have to execute an verification if the subject matches the
+  following requirements:
+    - The user has to have authorized the client;
+    - The client has to have authorization code flow enabled;
+    - The client has to be active;
+    - The redirect uri should match the configured for the client;
+    - The user has to be active;
+  """
+  @spec execute(input :: Input.t(), user_id :: String.t()) ::
+          {:ok, success_map()} | {:error, :unauthorized}
+  def execute(%Input{client_id: client_id} = input, user_id) when is_binary(user_id) do
+    with {:authorized?, true} <- {:authorized?, input.authorized},
+         {:app, {:ok, app}} <- {:app, Port.get_identity(%{client_id: client_id})},
+         {:flow_enabled?, true} <- {:flow_enabled?, "authorization_code" in app.grant_flows},
+         {:app_active?, true} <- {:app_active?, app.status == "active"},
+         {:same_redirect?, true} <- {:same_redirect?, app.redirect_uri == input.redirect_uri},
+         {:user, {:ok, user}} <- {:user, Port.get_identity(%GetUser{id: user_id})},
+         {:user_active?, true} <- {:user_active?, user.status == "active"} do
+      user
+      |> generate_authorization_code(app, input.scope)
+      |> parse_response()
+    else
+      {:authorized?, false} ->
+        Logger.info("Client not authorized by the user")
+        {:error, :unauthorized}
+
+      {:app, {:error, :not_found}} ->
+        Logger.info("Client application #{client_id} not found")
+        {:error, :unauthorized}
+
+      {:flow_enabled?, false} ->
+        Logger.info("Client application #{client_id} resource_owner flow not enabled")
+        {:error, :unauthorized}
+
+      {:app_active?, false} ->
+        Logger.info("Client application #{client_id} is not active")
+        {:error, :unauthorized}
+
+      {:same_redirect?, false} ->
+        Logger.info("Request redirect_uri is different from the configured for the client")
+        {:error, :unauthorized}
+
+      {:user, {:error, :not_found}} ->
+        Logger.info("User #{user_id} not found")
+        {:error, :unauthorized}
+
+      {:user_active?, false} ->
+        Logger.info("User #{user_id} is not active")
+        {:error, :unauthorized}
+    end
+  end
+
+  defp generate_authorization_code(user, application, scope) do
+    AuthorizationCode.generate_and_sign(%{
+      "aud" => application.client_id,
+      "azp" => application.name,
+      "sub" => user.id,
+      "typ" => "Bearer",
+      "identity" => "user",
+      "redirect_uri" => application.redirect_uri,
+      "scope" => build_scope(user, application, scope)
+    })
+  end
+
+  defp build_scope(user, application, scopes) do
+    user_scopes = Enum.map(user.scopes, & &1.name)
+    app_scopes = Enum.map(application.scopes, & &1.name)
+
+    scopes
+    |> Scopes.convert_to_list()
+    |> Enum.filter(&(&1 in app_scopes))
+    |> Enum.filter(&(&1 in user_scopes))
+    |> Scopes.convert_to_string()
+    |> case do
+      "" -> nil
+      scope -> scope
+    end
+  end
+
+  defp parse_response({:ok, code, %{"ttl" => ttl, "typ" => typ}}) do
+    payload = %{
+      authorization_code: code,
+      expires_in: ttl,
+      token_type: typ
+    }
+
+    {:ok, payload}
+  end
+
+  defp parse_response({:error, _reason} = error), do: error
+end

--- a/apps/authorizer/lib/rules/commands/inputs/authorization_code_sign_in.ex
+++ b/apps/authorizer/lib/rules/commands/inputs/authorization_code_sign_in.ex
@@ -1,0 +1,37 @@
+defmodule Authorizer.Rules.Commands.Inputs.AuthorizationCodeSignIn do
+  @moduledoc """
+  Input schema to be used in sign in authorizations.
+  """
+
+  use Authorizer.Input
+
+  @typedoc "Sign in authorization input fields"
+  @type t :: %__MODULE__{
+          client_id: String.t(),
+          response_type: String.t(),
+          redirect_uri: String.t() | nil,
+          scope: String.t()
+        }
+
+  @possible_response_type ~w(code)
+
+  @required [:client_id, :response_type, :scope, :state, :authorized]
+  @optional [:redirect_uri]
+  embedded_schema do
+    field :client_id, :string
+    field :response_type, :string
+    field :redirect_uri, :string
+    field :scope, :string
+    field :state, :string
+    field :authorized, :boolean
+  end
+
+  @doc false
+  def changeset(params) when is_map(params) do
+    %__MODULE__{}
+    |> cast(params, @required ++ @optional)
+    |> validate_inclusion(:response_type, @possible_response_type)
+    |> validate_length(:client_id, min: 1)
+    |> validate_required(@required)
+  end
+end

--- a/apps/authorizer/mix.exs
+++ b/apps/authorizer/mix.exs
@@ -28,7 +28,7 @@ defmodule Authorizer.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :runtime_tools]
     ]
   end
 
@@ -41,10 +41,15 @@ defmodule Authorizer.MixProject do
     [
       # Umbrella
       {:resource_manager, in_umbrella: true},
+      {:authenticator, in_umbrella: true},
 
       # Domain
       {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.0"},
+
+      # Database
+      {:postgrex, "~> 0.15"},
+      {:ecto_sql, "~> 3.6"},
 
       # Tools
       {:junit_formatter, "~> 3.2", only: [:test]},

--- a/apps/authorizer/test/rules/commands/authorization_code_sign_in_test.exs
+++ b/apps/authorizer/test/rules/commands/authorization_code_sign_in_test.exs
@@ -141,7 +141,7 @@ defmodule Authorizer.SignIn.Commands.AuthorizationCodeTest do
 
       app =
         RF.insert!(:client_application,
-        status: "inactive",
+          status: "inactive",
           redirect_uri: "https://redirect-test.com"
         )
 

--- a/apps/authorizer/test/rules/commands/authorization_code_sign_in_test.exs
+++ b/apps/authorizer/test/rules/commands/authorization_code_sign_in_test.exs
@@ -1,0 +1,257 @@
+defmodule Authorizer.SignIn.Commands.AuthorizationCodeTest do
+  use Authorizer.DataCase, async: true
+
+  alias Authenticator.Sessions.Tokens.AuthorizationCode
+  alias Authorizer.Ports.ResourceManagerMock
+  alias Authorizer.Rules.Commands.AuthorizationCodeSignIn, as: Command
+  alias Authorizer.Rules.Commands.Inputs.AuthorizationCodeSignIn, as: Input
+
+  describe "#{Command}.execute/1" do
+    test "succeeds and generates the authorization code" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+
+      app =
+        RF.insert!(:client_application,
+          grant_flows: ["authorization_code"],
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      subject_id = user.id
+      client_id = app.client_id
+      client_name = app.name
+      redirect_uri = app.redirect_uri
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      expect(ResourceManagerMock, :get_identity, fn %{id: id} ->
+        assert user.id == id
+        {:ok, %{user | scopes: scopes}}
+      end)
+
+      assert {:ok,
+              %{
+                authorization_code: authorization_code,
+                expires_in: 7200,
+                token_type: typ
+              }} = Command.execute(input, user.id)
+
+      assert {:ok,
+              %{
+                "aud" => ^client_id,
+                "azp" => ^client_name,
+                "exp" => _,
+                "iat" => _,
+                "iss" => "WatcherEx",
+                "jti" => _,
+                "nbf" => _,
+                "scope" => ^scope,
+                "identity" => "user",
+                "redirect_uri" => ^redirect_uri,
+                "sub" => ^subject_id,
+                "typ" => ^typ
+              }} = AuthorizationCode.verify_and_validate(authorization_code)
+    end
+
+    test "fails if input not authorized by the user" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+
+      app =
+        RF.insert!(:client_application,
+          grant_flows: ["authorization_code"],
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: false
+      }
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+
+    test "fails if client application not found" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: Ecto.UUID.generate(),
+        response_type: "code",
+        redirect_uri: "https://redirect-test.com",
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: _} ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+
+    test "fails if authorization code flow not enabled" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+
+      app =
+        RF.insert!(:client_application,
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+
+    test "fails if client is not active" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+
+      app =
+        RF.insert!(:client_application,
+        status: "inactive",
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+
+    test "fails if client redirect uri is different" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+
+      app =
+        RF.insert!(:client_application,
+          redirect_uri: "https://redirect-test2.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+
+    test "fails if user not found" do
+      scopes = RF.insert_list!(:scope, 3)
+
+      app =
+        RF.insert!(:client_application,
+          grant_flows: ["authorization_code"],
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      expect(ResourceManagerMock, :get_identity, fn %{id: _} ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, Ecto.UUID.generate())
+    end
+
+    test "fails if user not active" do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user, status: "inactive")
+
+      app =
+        RF.insert!(:client_application,
+          grant_flows: ["authorization_code"],
+          redirect_uri: "https://redirect-test.com"
+        )
+
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      input = %Input{
+        client_id: app.client_id,
+        response_type: "code",
+        redirect_uri: app.redirect_uri,
+        scope: scope,
+        authorized: true
+      }
+
+      expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
+        assert app.client_id == client_id
+        {:ok, %{app | public_key: nil, scopes: scopes}}
+      end)
+
+      expect(ResourceManagerMock, :get_identity, fn %{id: id} ->
+        assert user.id == id
+        {:ok, %{user | scopes: scopes}}
+      end)
+
+      assert {:error, :unauthorized} == Command.execute(input, user.id)
+    end
+  end
+end

--- a/apps/authorizer/test/support/data_case.ex
+++ b/apps/authorizer/test/support/data_case.ex
@@ -3,6 +3,8 @@ defmodule Authorizer.DataCase do
 
   use ExUnit.CaseTemplate
 
+  alias Ecto.Adapters.SQL.Sandbox
+
   using do
     quote do
       import Ecto
@@ -10,8 +12,23 @@ defmodule Authorizer.DataCase do
       import Mox
       import Authorizer.{DataCase, Factory}
 
+      alias Authenticator.Factory, as: AF
+      alias ResourceManager.Factory, as: RF
+
       setup :verify_on_exit!
     end
+  end
+
+  setup tags do
+    :ok = Sandbox.checkout(Authenticator.Repo)
+    :ok = Sandbox.checkout(ResourceManager.Repo)
+
+    unless tags[:async] do
+      Sandbox.mode(Authenticator.Repo, {:shared, self()})
+      Sandbox.mode(ResourceManager.Repo, {:shared, self()})
+    end
+
+    :ok
   end
 
   @doc """

--- a/apps/authorizer/test/test_helper.exs
+++ b/apps/authorizer/test/test_helper.exs
@@ -1,2 +1,5 @@
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()
+
+Ecto.Adapters.SQL.Sandbox.mode(Authenticator.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(ResourceManager.Repo, :manual)

--- a/apps/rest_api/lib/controllers/public/auth.ex
+++ b/apps/rest_api/lib/controllers/public/auth.ex
@@ -10,7 +10,9 @@ defmodule RestAPI.Controllers.Public.Auth do
     ResourceOwner
   }
 
-  alias RestAPI.Ports.Authenticator, as: Commands
+  alias Authorizer.Rules.Commands.Inputs.AuthorizationCodeSignIn
+
+  alias RestAPI.Ports.{Authenticator, Authorizer}
   alias RestAPI.Views.Public.Auth
 
   action_fallback RestAPI.Controllers.Fallback
@@ -28,7 +30,7 @@ defmodule RestAPI.Controllers.Public.Auth do
     params = Map.merge(params, conn.private.tracking)
 
     with {:ok, input} <- ResourceOwner.cast_and_apply(params),
-         {:ok, response} <- Commands.sign_in_resource_owner(input) do
+         {:ok, response} <- Authenticator.sign_in_resource_owner(input) do
       conn
       |> put_view(Auth)
       |> put_status(200)
@@ -40,7 +42,7 @@ defmodule RestAPI.Controllers.Public.Auth do
     params = Map.merge(params, conn.private.tracking)
 
     with {:ok, input} <- RefreshToken.cast_and_apply(params),
-         {:ok, response} <- Commands.sign_in_refresh_token(input) do
+         {:ok, response} <- Authenticator.sign_in_refresh_token(input) do
       conn
       |> put_view(Auth)
       |> put_status(200)
@@ -52,7 +54,7 @@ defmodule RestAPI.Controllers.Public.Auth do
     params = Map.merge(params, conn.private.tracking)
 
     with {:ok, input} <- ClientCredentials.cast_and_apply(params),
-         {:ok, response} <- Commands.sign_in_client_credentials(input) do
+         {:ok, response} <- Authenticator.sign_in_client_credentials(input) do
       conn
       |> put_view(Auth)
       |> put_status(200)
@@ -64,7 +66,7 @@ defmodule RestAPI.Controllers.Public.Auth do
     params = Map.merge(params, conn.private.tracking)
 
     with {:ok, input} <- AuthorizationCode.cast_and_apply(params),
-         {:ok, response} <- Commands.sign_in_authorization_code(input) do
+         {:ok, response} <- Authenticator.sign_in_authorization_code(input) do
       conn
       |> put_view(Auth)
       |> put_status(200)
@@ -72,11 +74,33 @@ defmodule RestAPI.Controllers.Public.Auth do
     end
   end
 
+  @doc """
+  Authorize an client to sign in the user later by using an authorization code.
+
+  This flow should only be used on authorization code grants.
+  """
+  @spec authorize(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
+  def authorize(%{private: %{session: session}} = conn, params) do
+    with {:ok, input} <- AuthorizationCodeSignIn.cast_and_apply(params),
+         {:ok, resp} <- Authorizer.authorize_authorization_code_sign_in(input, session.subject_id) do
+      if input.redirect_uri do
+        redirect(conn,
+          external: "#{input.redirect_uri}?code=#{resp.authorization_code}&state=#{input.state}"
+        )
+      else
+        conn
+        |> put_view(Auth)
+        |> put_status(200)
+        |> render("authorize.json", response: resp, state: input.state)
+      end
+    end
+  end
+
   @doc "Logout the authenticated subject session."
   @spec logout(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
   def logout(%{private: %{session: session}} = conn, _params) do
     session.jti
-    |> Commands.sign_out_session()
+    |> Authenticator.sign_out_session()
     |> case do
       {:ok, _any} -> send_resp(conn, :no_content, "")
       {:error, _reason} = error -> error
@@ -87,7 +111,7 @@ defmodule RestAPI.Controllers.Public.Auth do
   @spec logout_all_sessions(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
   def logout_all_sessions(%{private: %{session: session}} = conn, _params) do
     session.subject_id
-    |> Commands.sign_out_all_sessions(session.subject_type)
+    |> Authenticator.sign_out_all_sessions(session.subject_type)
     |> case do
       {:ok, _any} -> send_resp(conn, :no_content, "")
       {:error, _reason} = error -> error

--- a/apps/rest_api/lib/ports/authorizer.ex
+++ b/apps/rest_api/lib/ports/authorizer.ex
@@ -14,6 +14,10 @@ defmodule RestAPI.Ports.Authorizer do
   @doc "Delegates to Authorizer.authorize_public/1"
   @callback authorize_public(conn :: Conn.t()) :: possible_authorize_response()
 
+  @doc "Delegates to Authorizer.authorize_authorization_code_sign_in/1"
+  @callback authorize_authorization_code_sign_in(input :: struct(), user_id :: String.t()) ::
+              {:ok, map()} | {:error, :unauthorized}
+
   @doc "Authorizes the subject using admin rule"
   @spec authorize_admin(conn :: Conn.t()) :: possible_authorize_response()
   def authorize_admin(conn), do: implementation().authorize_admin(conn)
@@ -21,6 +25,12 @@ defmodule RestAPI.Ports.Authorizer do
   @doc "Authorizes the subject using public rule"
   @spec authorize_public(conn :: Conn.t()) :: possible_authorize_response()
   def authorize_public(conn), do: implementation().authorize_public(conn)
+
+  @doc "Authorizes the subject using public rule"
+  @spec authorize_authorization_code_sign_in(input :: struct(), user_id :: String.t()) ::
+          possible_authorize_response()
+  def authorize_authorization_code_sign_in(input, user_id),
+    do: implementation().authorize_authorization_code_sign_in(input, user_id)
 
   defp implementation do
     :rest_api

--- a/apps/rest_api/lib/routers/admin.ex
+++ b/apps/rest_api/lib/routers/admin.ex
@@ -10,10 +10,6 @@ defmodule RestAPI.Routers.Admin do
     plug Tracker
   end
 
-  pipeline :authorized_as_user do
-    plug Authorization, type: "public"
-  end
-
   pipeline :authorized_as_admin do
     plug Authorization, type: "admin"
   end

--- a/apps/rest_api/lib/routers/public.ex
+++ b/apps/rest_api/lib/routers/public.ex
@@ -4,11 +4,15 @@ defmodule RestAPI.Routers.Public do
   use RestAPI.Router
 
   alias RestAPI.Controllers.Public
-  alias RestAPI.Plugs.{Authentication, Tracker}
+  alias RestAPI.Plugs.{Authentication, Authorization, Tracker}
 
   pipeline :rest_api do
     plug :accepts, ["json"]
     plug Tracker
+  end
+
+  pipeline :authorized_as_user do
+    plug Authorization, type: "public"
   end
 
   pipeline :authenticated do
@@ -20,6 +24,13 @@ defmodule RestAPI.Routers.Public do
 
     scope "/auth/protocol/openid-connect" do
       post "/token", Auth, :token
+
+      scope "/authorize" do
+        pipe_through :authenticated
+        pipe_through :authorized_as_user
+
+        post "/", Auth, :authorize
+      end
 
       scope "/" do
         pipe_through :authenticated

--- a/apps/rest_api/lib/views/public/auth.ex
+++ b/apps/rest_api/lib/views/public/auth.ex
@@ -11,4 +11,11 @@ defmodule RestAPI.Views.Public.Auth do
       token_type: response.token_type
     }
   end
+
+  def render("authorize.json", %{response: response, state: state}) do
+    %{
+      code: response.authorization_code,
+      state: state
+    }
+  end
 end

--- a/apps/rest_api/test/controllers/public/auth_test.exs
+++ b/apps/rest_api/test/controllers/public/auth_test.exs
@@ -2,12 +2,154 @@ defmodule RestAPI.Controllers.Public.AuthTest do
   use RestAPI.ConnCase, async: true
 
   alias Authenticator.SignIn.Commands.Inputs.{ClientCredentials, RefreshToken, ResourceOwner}
-  alias RestAPI.Ports.AuthenticatorMock
+  alias RestAPI.Ports.{AuthenticatorMock, AuthorizerMock}
 
   @content_type "application/x-www-form-urlencoded"
   @token_endpoint "/api/v1/auth/protocol/openid-connect/token"
-  @logout_endpoint "api/v1/auth/protocol/openid-connect/logout"
-  @logout_all_endpoint "api/v1/auth/protocol/openid-connect/logout-all-sessions"
+  @authorization_code_endpoint "/api/v1/auth/protocol/openid-connect/authorize"
+  @logout_endpoint "/api/v1/auth/protocol/openid-connect/logout"
+  @logout_all_endpoint "/api/v1/auth/protocol/openid-connect/logout-all-sessions"
+
+  describe "POST #{@authorization_code_endpoint}" do
+    setup do
+      {:ok, access_token: "my-access-token", claims: default_claims()}
+    end
+
+    test "succeeds if params are valid", %{conn: conn, access_token: access_token, claims: claims} do
+      params = %{
+        "client_id" => Ecto.UUID.generate(),
+        "response_type" => "code",
+        "redirect_uri" => nil,
+        "scope" => "user:read",
+        "authorized" => true,
+        "state" => "my-state"
+      }
+
+      expect(AuthenticatorMock, :validate_access_token, fn token ->
+        assert access_token == token
+        {:ok, claims}
+      end)
+
+      expect(AuthenticatorMock, :get_session, fn %{"jti" => jti} ->
+        assert claims["jti"] == jti
+        {:ok, success_session(claims)}
+      end)
+
+      expect(AuthorizerMock, :authorize_public, fn %Plug.Conn{} -> :ok end)
+
+      expect(AuthorizerMock, :authorize_authorization_code_sign_in, fn _input, _user_id ->
+        {:ok, %{authorization_code: "my-code", expires_in: 999, token_type: "jwt"}}
+      end)
+
+      assert %{"code" => _, "state" => _} =
+               conn
+               |> put_req_header("authorization", "Bearer #{access_token}")
+               |> put_req_header("content-type", @content_type)
+               |> post(@authorization_code_endpoint, params)
+               |> json_response(200)
+    end
+
+    test "redirects response if params are valid", %{conn: conn, access_token: access_token, claims: claims} do
+      params = %{
+        "client_id" => Ecto.UUID.generate(),
+        "response_type" => "code",
+        "redirect_uri" => "https://localhost:4000/authorization-redirect",
+        "scope" => "user:read",
+        "authorized" => true,
+        "state" => "my-state"
+      }
+
+      expect(AuthenticatorMock, :validate_access_token, fn token ->
+        assert access_token == token
+        {:ok, claims}
+      end)
+
+      expect(AuthenticatorMock, :get_session, fn %{"jti" => jti} ->
+        assert claims["jti"] == jti
+        {:ok, success_session(claims)}
+      end)
+
+      expect(AuthorizerMock, :authorize_public, fn %Plug.Conn{} -> :ok end)
+
+      expect(AuthorizerMock, :authorize_authorization_code_sign_in, fn _input, _user_id ->
+        {:ok, %{authorization_code: "my-code", expires_in: 999, token_type: "jwt"}}
+      end)
+
+      assert conn =
+               conn
+               |> put_req_header("authorization", "Bearer #{access_token}")
+               |> put_req_header("content-type", @content_type)
+               |> post(@authorization_code_endpoint, params)
+
+      assert "https://localhost:4000/authorization-redirect?code=my-code&state=my-state" == redirected_to(conn)
+    end
+
+    test "fails if params are invalid", %{conn: conn, access_token: access_token, claims: claims} do
+      expect(AuthenticatorMock, :validate_access_token, fn token ->
+        assert access_token == token
+        {:ok, claims}
+      end)
+
+      expect(AuthenticatorMock, :get_session, fn %{"jti" => jti} ->
+        assert claims["jti"] == jti
+        {:ok, success_session(claims)}
+      end)
+
+      expect(AuthorizerMock, :authorize_public, fn %Plug.Conn{} -> :ok end)
+
+      assert %{
+               "detail" => "The given params failed in validation",
+               "error" => "bad_request",
+               "response" => %{
+                 "authorized" => ["can't be blank"],
+                 "client_id" => ["can't be blank"],
+                 "response_type" => ["can't be blank"],
+                 "scope" => ["can't be blank"],
+                 "state" => ["can't be blank"]
+               },
+               "status" => 400
+             } ==
+               conn
+               |> put_req_header("authorization", "Bearer #{access_token}")
+               |> put_req_header("content-type", @content_type)
+               |> post(@authorization_code_endpoint, %{})
+               |> json_response(400)
+    end
+
+    test "fails if not authorize", %{conn: conn, access_token: access_token, claims: claims} do
+      params = %{
+        "client_id" => Ecto.UUID.generate(),
+        "response_type" => "code",
+        "redirect_uri" => nil,
+        "scope" => "user:read",
+        "authorized" => false,
+        "state" => "my-state"
+      }
+
+      expect(AuthenticatorMock, :validate_access_token, fn token ->
+        assert access_token == token
+        {:ok, claims}
+      end)
+
+      expect(AuthenticatorMock, :get_session, fn %{"jti" => jti} ->
+        assert claims["jti"] == jti
+        {:ok, success_session(claims)}
+      end)
+
+      expect(AuthorizerMock, :authorize_public, fn %Plug.Conn{} -> :ok end)
+
+      expect(AuthorizerMock, :authorize_authorization_code_sign_in, fn _input, _user_id ->
+        {:error, :unauthorized}
+      end)
+
+      assert %{"detail" => "Not authorized to perform such action", "error" => "unauthorized", "status" => 401} ==
+               conn
+               |> put_req_header("authorization", "Bearer #{access_token}")
+               |> put_req_header("content-type", @content_type)
+               |> post(@authorization_code_endpoint, params)
+               |> json_response(401)
+    end
+  end
 
   describe "POST #{@token_endpoint}" do
     test "suceeds in Resource Owner Flow if params are valid", %{conn: conn} do

--- a/apps/rest_api/test/controllers/public/auth_test.exs
+++ b/apps/rest_api/test/controllers/public/auth_test.exs
@@ -49,7 +49,11 @@ defmodule RestAPI.Controllers.Public.AuthTest do
                |> json_response(200)
     end
 
-    test "redirects response if params are valid", %{conn: conn, access_token: access_token, claims: claims} do
+    test "redirects response if params are valid", %{
+      conn: conn,
+      access_token: access_token,
+      claims: claims
+    } do
       params = %{
         "client_id" => Ecto.UUID.generate(),
         "response_type" => "code",
@@ -81,7 +85,8 @@ defmodule RestAPI.Controllers.Public.AuthTest do
                |> put_req_header("content-type", @content_type)
                |> post(@authorization_code_endpoint, params)
 
-      assert "https://localhost:4000/authorization-redirect?code=my-code&state=my-state" == redirected_to(conn)
+      assert "https://localhost:4000/authorization-redirect?code=my-code&state=my-state" ==
+               redirected_to(conn)
     end
 
     test "fails if params are invalid", %{conn: conn, access_token: access_token, claims: claims} do
@@ -142,7 +147,11 @@ defmodule RestAPI.Controllers.Public.AuthTest do
         {:error, :unauthorized}
       end)
 
-      assert %{"detail" => "Not authorized to perform such action", "error" => "unauthorized", "status" => 401} ==
+      assert %{
+               "detail" => "Not authorized to perform such action",
+               "error" => "unauthorized",
+               "status" => 401
+             } ==
                conn
                |> put_req_header("authorization", "Bearer #{access_token}")
                |> put_req_header("content-type", @content_type)

--- a/dialyzer/ignore-warnings.exs
+++ b/dialyzer/ignore-warnings.exs
@@ -32,5 +32,7 @@
     {"lib/permissions/schemas/client_application_scope.ex", :unknown_type},
     {"lib/permissions/commands/consent_scope.ex", :unknown_type},
     {"lib/permissions/commands/remove_scope.ex", :unknown_type},
-    {"lib/phoenix/router.ex", :pattern_match, 402}
+    {"lib/controllers/public/admin.ex"},
+    {"lib/controllers/public/auth.ex"},
+    {"lib/phoenix/router.ex"}
 ]


### PR DESCRIPTION
Starts generating authorization codes.
Next step will be create the sign in and authorization page for the user to be redirected before executing this flow.