### PR TITLE
feat: add token revoke flow

### DIFF
--- a/apps/authenticator/lib/authenticator.ex
+++ b/apps/authenticator/lib/authenticator.ex
@@ -35,7 +35,7 @@ defmodule Authenticator do
   defdelegate validate_access_token(token), to: AccessToken, as: :verify_and_validate
 
   @doc "Delegates to #{RevokeTokens}.execute/1"
-  defdelegate revoke_tokens, to: RevokeTokens, as: :execute
+  defdelegate revoke_tokens(input), to: RevokeTokens, as: :execute
 
   @doc "Delegates to #{SignOutSession}.execute/1"
   defdelegate sign_out_session(session_or_jti), to: SignOutSession, as: :execute

--- a/apps/authenticator/lib/authenticator.ex
+++ b/apps/authenticator/lib/authenticator.ex
@@ -14,7 +14,7 @@ defmodule Authenticator do
     ResourceOwner
   }
 
-  alias Authenticator.SignOut.Commands.{SignOutAllSessions, SignOutSession}
+  alias Authenticator.SignOut.Commands.{RevokeTokens, SignOutAllSessions, SignOutSession}
 
   @doc "Delegates to #{ResourceOwner}.execute/1"
   defdelegate sign_in_resource_owner(input), to: ResourceOwner, as: :execute
@@ -33,6 +33,9 @@ defmodule Authenticator do
 
   @doc "Delegates to #{AccessToken}.verify_and_validate/1"
   defdelegate validate_access_token(token), to: AccessToken, as: :verify_and_validate
+
+  @doc "Delegates to #{RevokeTokens}.execute/1"
+  defdelegate revoke_tokens, to: RevokeTokens, as: :execute
 
   @doc "Delegates to #{SignOutSession}.execute/1"
   defdelegate sign_out_session(session_or_jti), to: SignOutSession, as: :execute

--- a/apps/authenticator/lib/repo.ex
+++ b/apps/authenticator/lib/repo.ex
@@ -2,4 +2,16 @@ defmodule Authenticator.Repo do
   @moduledoc false
 
   use Ecto.Repo, otp_app: :authenticator, adapter: Ecto.Adapters.Postgres
+
+  @doc "Encapsulates the given function into an transaction"
+  @spec execute_transaction(fun :: function()) :: {:ok, any()} | {:error, any()}
+  def execute_transaction(fun, opts \\ []) when is_function(fun) when is_list(opts) do
+    transaction(fn ->
+      case fun.() do
+        :ok -> :ok
+        {:ok, result} -> result
+        {:error, reason} -> rollback(reason)
+      end
+    end)
+  end
 end

--- a/apps/authenticator/lib/sessions/commands/get_session.ex
+++ b/apps/authenticator/lib/sessions/commands/get_session.ex
@@ -15,10 +15,10 @@ defmodule Authenticator.Sessions.Commands.GetSession do
 
   @doc "Returns a session using the given filters"
   @spec execute(input :: GetSession.t() | map()) :: possible_responses()
-  def execute(%GetSession{jti: jti} = input) do
+  def execute(%GetSession{jti: jti, type: type} = input) do
     Logger.info("Getting subject session")
 
-    jti
+    {jti, type}
     |> Cache.get()
     |> case do
       nil ->

--- a/apps/authenticator/lib/sessions/commands/inputs/get_session.ex
+++ b/apps/authenticator/lib/sessions/commands/inputs/get_session.ex
@@ -11,16 +11,18 @@ defmodule Authenticator.Sessions.Commands.Inputs.GetSession do
   @type t :: %__MODULE__{
           id: String.t(),
           jti: String.t(),
+          type: String.t(),
           subject_id: String.t(),
           subject_type: String.t(),
           status: String.t(),
           grant_flow: String.t()
         }
 
-  @optional [:id, :jti, :subject_id, :subject_type, :status, :grant_flow]
+  @optional [:id, :jti, :type, :subject_id, :subject_type, :status, :grant_flow]
   embedded_schema do
     field :id, Ecto.UUID
     field :jti, :string
+    field :type, :string
     field :subject_id, :string
     field :subject_type, :string
     field :status, :string
@@ -31,6 +33,7 @@ defmodule Authenticator.Sessions.Commands.Inputs.GetSession do
   def changeset(params) when is_map(params) do
     %__MODULE__{}
     |> cast(params, @optional)
+    |> validate_inclusion(:type, Session.possible_types())
     |> validate_inclusion(:status, Session.possible_statuses())
     |> validate_inclusion(:subject_type, Session.possible_subject_types())
     |> validate_inclusion(:grant_flow, Session.possible_grant_flows())

--- a/apps/authenticator/lib/sessions/manager.ex
+++ b/apps/authenticator/lib/sessions/manager.ex
@@ -156,9 +156,9 @@ defmodule Authenticator.Sessions.Manager do
     end
   end
 
-  defp build_cache(%Session{jti: jti, claims: %{"exp" => exp}} = session) do
+  defp build_cache(%Session{jti: jti, type: type, claims: %{"exp" => exp}} = session) do
     %Nebulex.Object{
-      key: jti,
+      key: {jti, type},
       value: session,
       version: 1,
       expire_at: exp

--- a/apps/authenticator/lib/sessions/schemas/session.ex
+++ b/apps/authenticator/lib/sessions/schemas/session.ex
@@ -16,6 +16,7 @@ defmodule Authenticator.Sessions.Schemas.Session do
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
           jti: String.t(),
+          type: String.t(),
           subject_id: String.t(),
           subject_type: String.t(),
           claims: map(),
@@ -26,14 +27,16 @@ defmodule Authenticator.Sessions.Schemas.Session do
           updated_at: NaiveDateTime.t()
         }
 
+  @possible_types ~w(access_token refresh_token)
   @possible_statuses ~w(active expired revoked refreshed)
   @possible_subject_types ~w(user application)
   @possible_grant_flows ~w(client_credentials resource_owner refresh_token)
 
-  @required_fields [:jti, :subject_id, :subject_type, :claims, :expires_at, :grant_flow]
+  @required_fields [:jti, :type, :subject_id, :subject_type, :claims, :expires_at, :grant_flow]
   @optional_fields [:status]
   schema "sessions" do
     field :jti, :string
+    field :type, :string
     field :subject_id, :string
     field :subject_type, :string
     field :claims, :map
@@ -48,6 +51,7 @@ defmodule Authenticator.Sessions.Schemas.Session do
   def changeset_create(params) when is_map(params) do
     %__MODULE__{}
     |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_inclusion(:type, @possible_types)
     |> validate_inclusion(:status, @possible_statuses)
     |> validate_inclusion(:subject_type, @possible_subject_types)
     |> validate_inclusion(:grant_flow, @possible_grant_flows)
@@ -60,6 +64,9 @@ defmodule Authenticator.Sessions.Schemas.Session do
     |> cast(params, @optional_fields)
     |> validate_inclusion(:status, @possible_statuses)
   end
+
+  @doc false
+  def possible_types, do: @possible_types
 
   @doc false
   def possible_statuses, do: @possible_statuses

--- a/apps/authenticator/lib/sessions/schemas/session.ex
+++ b/apps/authenticator/lib/sessions/schemas/session.ex
@@ -26,7 +26,7 @@ defmodule Authenticator.Sessions.Schemas.Session do
           updated_at: NaiveDateTime.t()
         }
 
-  @possible_statuses ~w(active expired invalidated refreshed)
+  @possible_statuses ~w(active expired revoked refreshed)
   @possible_subject_types ~w(user application)
   @possible_grant_flows ~w(client_credentials resource_owner refresh_token)
 

--- a/apps/authenticator/lib/sessions/tokens/refresh_token.ex
+++ b/apps/authenticator/lib/sessions/tokens/refresh_token.ex
@@ -5,8 +5,8 @@ defmodule Authenticator.Sessions.Tokens.RefreshToken do
 
   use Joken.Config
 
-  add_hook Joken.Hooks.RequiredClaims, ~w(exp iat nbf iss azp aud jti typ)
-  add_hook Authenticator.Sessions.Tokens.Hooks.ValidateUUID, ~w(aud)
+  add_hook Joken.Hooks.RequiredClaims, ~w(exp iat nbf iss azp aud jti typ sub)
+  add_hook Authenticator.Sessions.Tokens.Hooks.ValidateUUID, ~w(aud sub)
 
   # Thirty days in seconds
   @exp_in_seconds 60 * 60 * 24 * 30
@@ -23,6 +23,7 @@ defmodule Authenticator.Sessions.Tokens.RefreshToken do
     |> add_claim("exp", &gen_exp/0, fn exp, _, _ -> is_integer(exp) and valid_expiration?(exp) end)
     |> add_claim("typ", nil, fn type, _, _ -> type == @default_type end)
     |> add_claim("ati", nil, &is_binary/1)
+    |> add_claim("sub", nil, &is_binary/1)
   end
 
   defp gen_ttl, do: @exp_in_seconds

--- a/apps/authenticator/lib/sign_in/commands/client_credentials.ex
+++ b/apps/authenticator/lib/sign_in/commands/client_credentials.ex
@@ -131,8 +131,8 @@ defmodule Authenticator.SignIn.Commands.ClientCredentials do
     Repo.execute_transaction(fn ->
       with {:ok, access_token, access_claims} <- generate_access_token(app, input.scope),
            {:ok, refresh_token, refresh_claims} <- generate_refresh_token(app, access_claims),
-           {:ok, _session} <- generate_and_save(input, access_claims, "access_token"),
-           {:ok, _session} <- generate_and_save(input, refresh_claims, "refresh_token") do
+           {:ok, _session} <- generate_session(input, access_claims, "access_token"),
+           {:ok, _session} <- generate_session(input, refresh_claims, "refresh_token") do
         {:ok, {access_token, refresh_token, access_claims}}
       end
     end)
@@ -169,9 +169,9 @@ defmodule Authenticator.SignIn.Commands.ClientCredentials do
     end
   end
 
-  defp generate_and_save(_input, nil, _type), do: {:ok, :ignore}
+  defp generate_session(_input, nil, _type), do: {:ok, :ignore}
 
-  defp generate_and_save(input, claims, "access_token" = type) do
+  defp generate_session(input, claims, "access_token" = type) do
     Multi.new()
     |> Multi.run(:save_attempt, fn _repo, _changes -> generate_attempt(input, true) end)
     |> Multi.run(:generate, fn _repo, _changes -> generate_session(claims, type) end)
@@ -187,7 +187,7 @@ defmodule Authenticator.SignIn.Commands.ClientCredentials do
     end
   end
 
-  defp generate_and_save(_input, claims, "refresh_token" = type) do
+  defp generate_session(_input, claims, "refresh_token" = type) do
     case generate_session(claims, type) do
       {:ok, session} ->
         Logger.info("Succeeds in creating refresh token session", id: session.id)

--- a/apps/authenticator/lib/sign_in/commands/refresh_token.ex
+++ b/apps/authenticator/lib/sign_in/commands/refresh_token.ex
@@ -30,7 +30,7 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
   @impl true
   def execute(%Input{refresh_token: token}) do
     with {:token, {:ok, claims}} <- {:token, RefreshToken.verify_and_validate(token)},
-         {:session, {:ok, session}} <- {:session, GetSession.execute(%{jti: claims["ati"]})},
+         {:session, {:ok, session}} <- {:session, get_session(claims["jti"], "refresh_token")},
          {:valid?, true} <- {:valid?, session.status not in ["revoked", "refreshed"]},
          {:app, {:ok, app}} <- {:app, Port.get_identity(%{client_id: claims["aud"]})},
          {:flow_enabled?, true} <- {:flow_enabled?, "refresh_token" in app.grant_flows},
@@ -38,9 +38,7 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
          {:app_active?, true} <- {:app_active?, app.status == "active"},
          {:subject, {:ok, subject}} <- {:subject, get_subject(session)},
          {:sub_active?, true} <- {:sub_active?, subject.status == "active"},
-         {:ok, access_token, claims} <- generate_access_token(session.claims),
-         {:ok, refresh_token, _} <- generate_refresh_token(claims),
-         {:ok, _session} <- generate_session(session, claims) do
+         {:ok, access_token, refresh_token, claims} <- generate_tokens(session) do
       {:ok, parse_response(access_token, refresh_token, claims)}
     else
       {:token, {:error, reason}} ->
@@ -105,11 +103,23 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
 
   def execute(_any), do: {:error, :invalid_params}
 
+  defp get_session(jti, type), do: GetSession.execute(%{jti: jti, type: type})
+
   defp get_subject(%{subject_id: subject_id, subject_type: "user"}),
     do: Port.get_identity(%{username: nil, id: subject_id})
 
   defp get_subject(%{subject_id: subject_id, subject_type: "application"}),
     do: Port.get_identity(%{client_id: nil, id: subject_id})
+
+  defp generate_tokens(%{claims: %{"ati" => ati}} = refresh_session) do
+    with {:ok, %{claims: claims} = access_session} <- get_session(ati, "access_token"),
+         {:ok, access_token, access_claims} <- generate_access_token(claims),
+         {:ok, refresh_token, refresh_claims} <- generate_refresh_token(access_claims),
+         {:ok, _session} <- generate_session(access_session, access_claims, "access_token"),
+         {:ok, _session} <- generate_session(refresh_session, refresh_claims, "refresh_token") do
+      {:ok, access_token, refresh_token, access_claims}
+    end
+  end
 
   defp generate_access_token(%{
          "aud" => aud,
@@ -128,16 +138,39 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
     })
   end
 
-  defp generate_refresh_token(%{"aud" => aud, "azp" => azp, "jti" => jti}) do
+  defp generate_refresh_token(%{"aud" => aud, "azp" => azp, "jti" => jti, "sub" => sub}) do
     RefreshToken.generate_and_sign(%{
       "aud" => aud,
       "azp" => azp,
+      "sub" => sub,
       "ati" => jti,
       "typ" => "Bearer"
     })
   end
 
-  defp generate_session(session, %{"jti" => jti, "exp" => exp} = claims) do
+  defp generate_session(session, %{"jti" => jti, "exp" => exp} = claims, "access_token" = type) do
+    %{
+      jti: jti,
+      type: type,
+      subject_id: session.subject_id,
+      subject_type: session.subject_type,
+      claims: claims,
+      expires_at: Sessions.convert_expiration(exp),
+      grant_flow: "refresh_token"
+    }
+    |> Sessions.create()
+    |> case do
+      {:ok, %Session{} = session} ->
+        Logger.info("Succeeds in generating a refresh token session", id: session.id)
+        {:ok, session}
+
+      {:error, reason} = error ->
+        Logger.error("Failed to generate a refresh token session", reason: reason)
+        error
+    end
+  end
+
+  defp generate_session(session, %{"jti" => jti, "exp" => exp} = claims, "refresh_token" = type) do
     Multi.new()
     |> Multi.run(:update, fn _repo, _changes ->
       Sessions.update(session, %{status: "refreshed"})
@@ -145,6 +178,7 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
     |> Multi.run(:create, fn _repo, _changes ->
       Sessions.create(%{
         jti: jti,
+        type: type,
         subject_id: session.subject_id,
         subject_type: session.subject_type,
         claims: claims,
@@ -155,11 +189,14 @@ defmodule Authenticator.SignIn.Commands.RefreshToken do
     |> Repo.transaction()
     |> case do
       {:ok, %{create: %Session{} = session}} ->
-        Logger.info("Succeeds in generating a session", id: session.id)
+        Logger.info("Succeeds in generating a refresh token session", id: session.id)
         {:ok, session}
 
       {:error, step, reason, _changes} ->
-        Logger.error("Failed to generate a session in step #{inspect(step)}", reason: reason)
+        Logger.error("Failed to generate a refresh token session in step #{inspect(step)}",
+          reason: reason
+        )
+
         {:error, reason}
     end
   end

--- a/apps/authenticator/lib/sign_in/commands/resource_owner.ex
+++ b/apps/authenticator/lib/sign_in/commands/resource_owner.ex
@@ -148,10 +148,11 @@ defmodule Authenticator.SignIn.Commands.ResourceOwner do
   end
 
   defp generate_tokens(user, app, input) do
-    with {:ok, access_token, claims} <- generate_access_token(user, app, input.scope),
-         {:ok, refresh_token, _} <- generate_refresh_token(app, claims),
-         {:ok, _session} <- generate_and_save(input, claims) do
-      {:ok, access_token, refresh_token, claims}
+    with {:ok, access_token, access_claims} <- generate_access_token(user, app, input.scope),
+         {:ok, refresh_token, refresh_claims} <- generate_refresh_token(app, access_claims),
+         {:ok, _session} <- generate_and_save(input, access_claims, "access_token"),
+         {:ok, _session} <- generate_and_save(input, refresh_claims, "refresh_token") do
+      {:ok, access_token, refresh_token, access_claims}
     end
   end
 
@@ -199,12 +200,18 @@ defmodule Authenticator.SignIn.Commands.ResourceOwner do
     })
   end
 
-  defp generate_refresh_token(application, %{"aud" => aud, "azp" => azp, "jti" => jti}) do
+  defp generate_refresh_token(application, %{
+         "aud" => aud,
+         "sub" => sub,
+         "azp" => azp,
+         "jti" => jti
+       }) do
     if "refresh_token" in application.grant_flows do
       RefreshToken.generate_and_sign(%{
         "aud" => aud,
         "azp" => azp,
         "ati" => jti,
+        "sub" => sub,
         "typ" => "Bearer"
       })
     else
@@ -213,19 +220,36 @@ defmodule Authenticator.SignIn.Commands.ResourceOwner do
     end
   end
 
-  defp generate_and_save(input, claims) do
+  defp generate_and_save(_input, nil, _type), do: {:ok, :ignored}
+
+  defp generate_and_save(input, claims, "access_token" = type) do
     Multi.new()
     |> Multi.run(:save_attempt, fn _repo, _changes -> generate_attempt(input, true) end)
-    |> Multi.run(:generate, fn _repo, _changes -> generate_session(claims) end)
+    |> Multi.run(:generate, fn _repo, _changes -> generate_session(claims, type) end)
     |> Repo.transaction()
     |> case do
       {:ok, %{generate: session}} ->
-        Logger.info("Succeeds in creating session", id: session.id)
+        Logger.info("Succeeds in access token creating session", id: session.id)
         {:ok, session}
 
       {:error, step, reason, _changes} ->
-        Logger.error("Failed to create session in step #{inspect(step)}", reason: reason)
+        Logger.error("Failed to create access token session in step #{inspect(step)}",
+          reason: reason
+        )
+
         {:error, reason}
+    end
+  end
+
+  defp generate_and_save(_input, claims, "refresh_token" = type) do
+    case generate_session(claims, type) do
+      {:ok, session} ->
+        Logger.info("Succeeds in creating refresh token session", id: session.id)
+        {:ok, session}
+
+      {:error, reason} = error ->
+        Logger.error("Failed to create refresh token session", reason: reason)
+        error
     end
   end
 
@@ -237,9 +261,10 @@ defmodule Authenticator.SignIn.Commands.ResourceOwner do
     })
   end
 
-  defp generate_session(%{"jti" => jti, "sub" => sub, "exp" => exp} = claims) do
+  defp generate_session(%{"jti" => jti, "sub" => sub, "exp" => exp} = claims, type) do
     Sessions.create(%{
       jti: jti,
+      type: type,
       subject_id: sub,
       subject_type: "user",
       claims: claims,

--- a/apps/authenticator/lib/sign_in/commands/resource_owner.ex
+++ b/apps/authenticator/lib/sign_in/commands/resource_owner.ex
@@ -202,16 +202,16 @@ defmodule Authenticator.SignIn.Commands.ResourceOwner do
 
   defp generate_refresh_token(application, %{
          "aud" => aud,
-         "sub" => sub,
          "azp" => azp,
-         "jti" => jti
+         "jti" => jti,
+         "sub" => sub
        }) do
     if "refresh_token" in application.grant_flows do
       RefreshToken.generate_and_sign(%{
         "aud" => aud,
+        "sub" => sub,
         "azp" => azp,
         "ati" => jti,
-        "sub" => sub,
         "typ" => "Bearer"
       })
     else

--- a/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
@@ -1,0 +1,26 @@
+defmodule Authenticator.SignOut.Commands.Inputs.RevokeTokens do
+  @moduledoc """
+  Input schema to be used in Revoke Tokens flow.
+  """
+
+  use Authenticator.Input
+
+  @typedoc "Revoke Tokens flow input fields"
+  @type t :: %__MODULE__{
+          access_token: String.t() | nil,
+          refresh_token: String.t() | nil
+        }
+
+  @required [:access_token, :refresh_token]
+  embedded_schema do
+    field :access_token, :string
+    field :refresh_token, :string
+  end
+
+  @doc false
+  def changeset(params) when is_map(params) do
+    %__MODULE__{}
+    |> cast(params, @required ++ @optional)
+    |> validate_required(@required)
+  end
+end

--- a/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
@@ -11,16 +11,12 @@ defmodule Authenticator.SignOut.Commands.Inputs.RevokeTokens do
           refresh_token: String.t() | nil
         }
 
-  @required [:access_token, :refresh_token]
+  @optional [:access_token, :refresh_token]
   embedded_schema do
     field :access_token, :string
     field :refresh_token, :string
   end
 
   @doc false
-  def changeset(params) when is_map(params) do
-    %__MODULE__{}
-    |> cast(params, @required ++ @optional)
-    |> validate_required(@required)
-  end
+  def changeset(params) when is_map(params), do: cast(%__MODULE__{}, params, @optional)
 end

--- a/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
@@ -1,0 +1,13 @@
+defmodule Authenticator.SignOut.Commands.RevokeTokens do
+  @moduledoc """
+  Invalidates all subject sessions.
+  """
+
+  alias Authenticator.SignOut.Commands.Inputs.RevokeTokens
+
+  require Logger
+
+  def execute(%RevokeTokens{} = input) do
+    {:ok, []}
+  end
+end

--- a/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
@@ -1,13 +1,54 @@
 defmodule Authenticator.SignOut.Commands.RevokeTokens do
   @moduledoc """
-  Invalidates all subject sessions.
+  Revoke access token and refresh token sessions
   """
 
+  alias Authenticator.Repo
+  alias Authenticator.Sessions.Schemas.Session
+  alias Authenticator.Sessions.Tokens.{AccessToken, RefreshToken}
   alias Authenticator.SignOut.Commands.Inputs.RevokeTokens
+  alias Authenticator.SignOut.Commands.SignOutSession
 
   require Logger
 
-  def execute(%RevokeTokens{} = input) do
-    {:ok, []}
+  @typedoc "All possible command error reasons"
+  @type possible_errors ::
+          Ecto.Changeset.t()
+          | :delete_cache_failed
+          | :not_active
+          | :not_active
+          | :anauthenticated
+
+  @typedoc "All possible command responses"
+  @type possible_responses ::
+          {:ok, {access_session :: Session.t() | nil, refresh_session :: Session.t() | nil}}
+          | {:error, possible_errors()}
+
+  @doc "Revoke the subject access token and/or refresh token sessions."
+  @spec execute(input :: RevokeTokens.t()) :: possible_responses()
+  def execute(%RevokeTokens{access_token: access_token, refresh_token: refresh_token}) do
+    Repo.execute_transaction(fn ->
+      with {:ok, access_session} <- revoke_token(access_token, AccessToken),
+           {:ok, refresh_session} <- revoke_token(refresh_token, RefreshToken) do
+        {:ok, {access_session, refresh_session}}
+      end
+    end)
+  end
+
+  defp revoke_token(nil, _module), do: {:ok, nil}
+
+  defp revoke_token(token, module) when is_binary(token) and is_atom(module) do
+    with {:token, {:ok, %{"jti" => jti}}} <- {:token, module.verify_and_validate(token)},
+         {:session, {:ok, session}} <- {:session, SignOutSession.execute(jti)} do
+      {:ok, session}
+    else
+      {:token, {:error, reason}} ->
+        Logger.error("Failed to validate token #{inspect(module)} because #{inspect(reason)}")
+        {:error, :anauthenticated}
+
+      {:session, {:error, r} = error} ->
+        Logger.error("Failed to revoke session token #{inspect(module)} because #{inspect(r)}")
+        error
+    end
   end
 end

--- a/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/revoke_tokens.ex
@@ -4,6 +4,7 @@ defmodule Authenticator.SignOut.Commands.RevokeTokens do
   """
 
   alias Authenticator.Repo
+  alias Authenticator.Sessions.Commands.GetSession
   alias Authenticator.Sessions.Schemas.Session
   alias Authenticator.Sessions.Tokens.{AccessToken, RefreshToken}
   alias Authenticator.SignOut.Commands.Inputs.RevokeTokens
@@ -28,27 +29,35 @@ defmodule Authenticator.SignOut.Commands.RevokeTokens do
   @spec execute(input :: RevokeTokens.t()) :: possible_responses()
   def execute(%RevokeTokens{access_token: access_token, refresh_token: refresh_token}) do
     Repo.execute_transaction(fn ->
-      with {:ok, access_session} <- revoke_token(access_token, AccessToken),
-           {:ok, refresh_session} <- revoke_token(refresh_token, RefreshToken) do
+      with {:ok, access_session} <- revoke_token(access_token, "access_token"),
+           {:ok, refresh_session} <- revoke_token(refresh_token, "refresh_token") do
         {:ok, {access_session, refresh_session}}
       end
     end)
   end
 
-  defp revoke_token(nil, _module), do: {:ok, nil}
+  defp revoke_token(nil, _type), do: {:ok, nil}
 
-  defp revoke_token(token, module) when is_binary(token) and is_atom(module) do
-    with {:token, {:ok, %{"jti" => jti}}} <- {:token, module.verify_and_validate(token)},
-         {:session, {:ok, session}} <- {:session, SignOutSession.execute(jti)} do
+  defp revoke_token(token, type) do
+    with {:token, {:ok, %{"jti" => jti}}} <- {:token, validate_token(token, type)},
+         {:session, {:ok, session}} <- {:session, GetSession.execute(%{jti: jti, type: type})},
+         {:revoke, {:ok, session}} <- {:revoke, SignOutSession.execute(session)} do
       {:ok, session}
     else
       {:token, {:error, reason}} ->
-        Logger.error("Failed to validate token #{inspect(module)} because #{inspect(reason)}")
+        Logger.error("Failed to validate #{inspect(type)} because #{inspect(reason)}")
         {:error, :anauthenticated}
 
-      {:session, {:error, r} = error} ->
-        Logger.error("Failed to revoke session token #{inspect(module)} because #{inspect(r)}")
+      {:session, {:error, :not_found}} ->
+        Logger.error("failed to get #{inspect(type)} session")
+        {:error, :anauthenticated}
+
+      {:revoke, {:error, reason} = error} ->
+        Logger.error("Failed to revoke session #{inspect(type)} because #{inspect(reason)}")
         error
     end
   end
+
+  defp validate_token(token, "access_token"), do: AccessToken.verify_and_validate(token)
+  defp validate_token(token, "refres_token"), do: RefreshToken.verify_and_validate(token)
 end

--- a/apps/authenticator/lib/sign_out/commands/sign_out_all_sessions.ex
+++ b/apps/authenticator/lib/sign_out/commands/sign_out_all_sessions.ex
@@ -17,7 +17,7 @@ defmodule Authenticator.SignOut.Commands.SignOutAllSessions do
     |> Multi.run(:invalidate, fn _repo, _changes ->
       [status: "active", subject_id: subject_id, subject_type: subject_type]
       |> Session.query()
-      |> Repo.update_all(set: [status: "invalidated"])
+      |> Repo.update_all(set: [status: "revoked"])
       |> case do
         {count, _} when is_integer(count) -> {:ok, count}
         {:error, _reason} = error -> error

--- a/apps/authenticator/lib/sign_out/commands/sign_out_session.ex
+++ b/apps/authenticator/lib/sign_out/commands/sign_out_session.ex
@@ -42,12 +42,13 @@ defmodule Authenticator.SignOut.Commands.SignOutSession do
     end
   end
 
+  def execute(%Session{}), do: {:error, :not_active}
+
   def execute(jti) when is_binary(jti) do
     [jti: jti]
     |> Sessions.get_by()
     |> case do
-      %Session{status: "active"} = session -> execute(session)
-      %Session{} -> {:error, :not_active}
+      %Session{} = session -> execute(session)
       _any -> {:error, :not_found}
     end
   end

--- a/apps/authenticator/lib/sign_out/commands/sign_out_session.ex
+++ b/apps/authenticator/lib/sign_out/commands/sign_out_session.ex
@@ -20,7 +20,7 @@ defmodule Authenticator.SignOut.Commands.SignOutSession do
   def execute(%Session{status: "active"} = session) do
     Multi.new()
     |> Multi.run(:invalidate, fn _repo, _changes ->
-      Sessions.update(session, %{status: "invalidated"})
+      Sessions.update(session, %{status: "revoked"})
     end)
     |> Multi.run(:delete_cache, fn _repo, %{invalidate: session} ->
       session.jti

--- a/apps/authenticator/priv/repo/migrations/20210731124222_alter_table_sessions_add_type.exs
+++ b/apps/authenticator/priv/repo/migrations/20210731124222_alter_table_sessions_add_type.exs
@@ -1,0 +1,11 @@
+defmodule Authenticator.Repo.Migrations.AlterTableSessionsAddType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sessions) do
+      add :type, :string, null: false
+    end
+
+    create_if_not_exists index(:sessions, [:jti, :type])
+  end
+end

--- a/apps/authenticator/test/authenticator/sessions/manager_test.exs
+++ b/apps/authenticator/test/authenticator/sessions/manager_test.exs
@@ -44,9 +44,9 @@ defmodule Authenticator.Sessions.ManagerTest do
             |> NaiveDateTime.truncate(:second)
         )
 
-      invalidated_session =
+      revoked_session =
         insert!(:session,
-          status: "invalidated",
+          status: "revoked",
           inserted_at:
             NaiveDateTime.utc_now()
             |> NaiveDateTime.add(-120)
@@ -59,7 +59,7 @@ defmodule Authenticator.Sessions.ManagerTest do
 
       assert {:ok, :sessions_updated} == Manager.execute()
       assert %Session{status: "refreshed"} = Repo.get(Session, refreshed_session.id)
-      assert %Session{status: "invalidated"} = Repo.get(Session, invalidated_session.id)
+      assert %Session{status: "revoked"} = Repo.get(Session, revoked_session.id)
       assert %Session{status: "active"} = Repo.get(Session, ctx.active_session.id)
     end
   end

--- a/apps/authenticator/test/authenticator/sessions_test.exs
+++ b/apps/authenticator/test/authenticator/sessions_test.exs
@@ -14,6 +14,7 @@ defmodule Authenticator.Sessions.SessionsTest do
     test "succeed if params are valid" do
       params = %{
         jti: Ecto.UUID.generate(),
+        type: "access_token",
         subject_id: Ecto.UUID.generate(),
         subject_type: "user",
         claims: %{},
@@ -30,13 +31,14 @@ defmodule Authenticator.Sessions.SessionsTest do
       assert {:error, changeset} = Sessions.create(%{})
 
       assert %{
+               type: ["can't be blank"],
                claims: ["can't be blank"],
                expires_at: ["can't be blank"],
                grant_flow: ["can't be blank"],
                jti: ["can't be blank"],
                subject_id: ["can't be blank"],
                subject_type: ["can't be blank"]
-             } = errors_on(changeset)
+             } == errors_on(changeset)
     end
   end
 
@@ -50,7 +52,7 @@ defmodule Authenticator.Sessions.SessionsTest do
 
     test "fails if params are invalid", ctx do
       assert {:error, changeset} = Sessions.update(ctx.session, %{status: 123})
-      assert %{status: ["is invalid"]} = errors_on(changeset)
+      assert %{status: ["is invalid"]} == errors_on(changeset)
     end
 
     test "raises if session does not exist" do

--- a/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
+++ b/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
@@ -212,7 +212,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
                Command.execute(%{refresh_token: token, grant_type: "refresh_token"})
     end
 
-    test "fails if session was invalidated" do
+    test "fails if session was revoked" do
       app_id = Ecto.UUID.generate()
       user_id = Ecto.UUID.generate()
 
@@ -232,7 +232,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         subject_id: user_id,
         subject_type: "user",
         claims: claims,
-        status: "invalidated"
+        status: "revoked"
       )
 
       refresh_token_claims = %{

--- a/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
+++ b/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
@@ -212,7 +212,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
     test "fails if params are invalid" do
       assert {:error, :invalid_params} == Command.execute(%{})
       assert {:error, changeset} = Command.execute(%{grant_type: "refresh_token"})
-      assert %{refresh_token: ["can't be blank"]} = errors_on(changeset)
+      assert %{refresh_token: ["can't be blank"]} == errors_on(changeset)
     end
 
     test "fails if resfresh token session does not exist" do

--- a/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
+++ b/apps/authenticator/test/authenticator/sign_in/commands/refresh_token_test.exs
@@ -30,16 +30,31 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
 
       {:ok, _token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
 
-      insert!(:session, jti: jti, subject_id: subject_id, subject_type: "user", claims: claims)
+      insert!(:session,
+        jti: jti,
+        type: "access_token",
+        subject_id: subject_id,
+        subject_type: "user",
+        claims: claims
+      )
 
       refresh_token_claims = %{
         "aud" => client_id,
         "azp" => app.name,
         "typ" => "Bearer",
+        "sub" => subject_id,
         "ati" => jti
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        type: "refresh_token",
+        subject_id: subject_id,
+        subject_type: "user",
+        claims: claims
+      )
 
       expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
         assert app.client_id == client_id
@@ -68,7 +83,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
                 "exp" => _,
                 "iat" => _,
                 "iss" => "WatcherEx",
-                "jti" => jti,
+                "jti" => ati,
                 "nbf" => _,
                 "scope" => ^scope,
                 "identity" => "user",
@@ -76,22 +91,27 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
                 "typ" => ^typ
               }} = AccessToken.verify_and_validate(access_token)
 
+      assert %Session{jti: ^ati, status: "active", type: "access_token"} =
+               Repo.get_by(Session, jti: ati)
+
       assert {:ok,
               %{
                 "aud" => ^client_id,
-                "ati" => ^jti,
+                "ati" => ^ati,
                 "exp" => _,
                 "iat" => _,
                 "iss" => "WatcherEx",
-                "jti" => _,
+                "jti" => jti,
                 "nbf" => _,
-                "typ" => ^typ
+                "typ" => ^typ,
+                "sub" => _
               }} = RefreshToken.verify_and_validate(refresh_token)
 
-      assert %Session{jti: ^jti, status: "active"} = Repo.get_by(Session, jti: jti)
+      assert %Session{jti: ^jti, status: "active", type: "refresh_token"} =
+               Repo.get_by(Session, jti: jti)
     end
 
-    test "succeeds even if session is expired" do
+    test "succeeds even if access token session is expired" do
       scopes = RF.insert_list!(:scope, 3)
       user = RF.insert!(:user)
       app = RF.insert!(:client_application, grant_flows: ["resource_owner", "refresh_token"])
@@ -117,17 +137,27 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         subject_id: subject_id,
         subject_type: "user",
         claims: claims,
-        status: "expired"
+        status: "expired",
+        type: "access_token"
       )
 
       refresh_token_claims = %{
         "aud" => client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => subject_id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: subject_id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn %{client_id: client_id} ->
         assert app.client_id == client_id
@@ -185,7 +215,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
       assert %{refresh_token: ["can't be blank"]} = errors_on(changeset)
     end
 
-    test "fails if session does not exist" do
+    test "fails if resfresh token session does not exist" do
       app_id = Ecto.UUID.generate()
       user_id = Ecto.UUID.generate()
 
@@ -197,13 +227,23 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         "scope" => "admin:read"
       }
 
-      {:ok, _token, %{"jti" => jti}} = build_access_token(access_token_claims)
+      {:ok, _token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user_id,
+        subject_type: "user",
+        claims: claims,
+        status: "expired",
+        type: "access_token"
+      )
 
       refresh_token_claims = %{
         "aud" => app_id,
         "azp" => "My application",
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user_id
       }
 
       {:ok, token, _} = build_refresh_token(refresh_token_claims)
@@ -212,7 +252,7 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
                Command.execute(%{refresh_token: token, grant_type: "refresh_token"})
     end
 
-    test "fails if session was revoked" do
+    test "fails if refresh token session was revoked" do
       app_id = Ecto.UUID.generate()
       user_id = Ecto.UUID.generate()
 
@@ -232,17 +272,28 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         subject_id: user_id,
         subject_type: "user",
         claims: claims,
-        status: "revoked"
+        status: "expired",
+        type: "access_token"
       )
 
       refresh_token_claims = %{
         "aud" => app_id,
         "azp" => "My application",
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user_id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user_id,
+        subject_type: "user",
+        claims: claims,
+        status: "revoked",
+        type: "refresh_token"
+      )
 
       assert {:error, :unauthenticated} ==
                Command.execute(%{refresh_token: token, grant_type: "refresh_token"})
@@ -268,17 +319,28 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         subject_id: user_id,
         subject_type: "user",
         claims: claims,
-        status: "refreshed"
+        status: "expired",
+        type: "access_token"
       )
 
       refresh_token_claims = %{
         "aud" => app_id,
         "azp" => "My application",
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user_id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user_id,
+        subject_type: "user",
+        claims: claims,
+        status: "refreshed",
+        type: "refresh_token"
+      )
 
       assert {:error, :unauthenticated} ==
                Command.execute(%{refresh_token: token, grant_type: "refresh_token"})
@@ -300,16 +362,31 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
 
       {:ok, _token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
 
-      insert!(:session, jti: jti, subject_id: user.id, subject_type: "user", claims: claims)
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "access_token"
+      )
 
       refresh_token_claims = %{
         "aud" => app.client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user.id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, app} end)
 
@@ -339,16 +416,31 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
 
       {:ok, _token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
 
-      insert!(:session, jti: jti, subject_id: user.id, subject_type: "user", claims: claims)
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "access_token"
+      )
 
       refresh_token_claims = %{
         "aud" => app.client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user.id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, app} end)
 
@@ -378,16 +470,31 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
 
       {:ok, _token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
 
-      insert!(:session, jti: jti, subject_id: user.id, subject_type: "user", claims: claims)
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "access_token"
+      )
 
       refresh_token_claims = %{
         "aud" => app.client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user.id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, app} end)
 
@@ -416,17 +523,27 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         jti: jti,
         subject_id: subject_id,
         subject_type: "user",
-        claims: claims
+        claims: claims,
+        type: "access_token"
       )
 
       refresh_token_claims = %{
         "aud" => app.client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => subject_id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: subject_id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, app} end)
       expect(ResourceManagerMock, :get_identity, fn _ -> {:error, :not_found} end)
@@ -455,17 +572,27 @@ defmodule Authenticator.SignIn.Commands.RefreshTokenTest do
         jti: jti,
         subject_id: user.id,
         subject_type: "user",
-        claims: claims
+        claims: claims,
+        type: "access_token"
       )
 
       refresh_token_claims = %{
         "aud" => app.client_id,
         "azp" => app.name,
         "typ" => "Bearer",
-        "ati" => jti
+        "ati" => jti,
+        "sub" => user.id
       }
 
-      {:ok, token, _} = build_refresh_token(refresh_token_claims)
+      {:ok, token, %{"jti" => jti} = claims} = build_refresh_token(refresh_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: user.id,
+        subject_type: "user",
+        claims: claims,
+        type: "refresh_token"
+      )
 
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, app} end)
       expect(ResourceManagerMock, :get_identity, fn _ -> {:ok, user} end)

--- a/apps/authenticator/test/authenticator/sign_in/commands/resource_owner_test.exs
+++ b/apps/authenticator/test/authenticator/sign_in/commands/resource_owner_test.exs
@@ -134,7 +134,7 @@ defmodule Authenticator.SignIn.Commands.ResourceOwnerTest do
               }} = AccessToken.verify_and_validate(access_token)
 
       assert %UserAttempt{username: ^username} = Repo.one(UserAttempt)
-      assert %Session{jti: ^jti} = Repo.one(Session)
+      assert %Session{jti: ^jti, type: "access_token"} = Repo.one(Session)
     end
 
     test "succeeds and generates a refresh_token" do
@@ -176,22 +176,25 @@ defmodule Authenticator.SignIn.Commands.ResourceOwnerTest do
                 token_type: typ
               }} = Command.execute(input)
 
-      assert {:ok, %{"jti" => jti}} = RefreshToken.verify_and_validate(access_token)
+      assert {:ok, %{"jti" => ati}} = RefreshToken.verify_and_validate(access_token)
 
       assert {:ok,
               %{
                 "aud" => ^client_id,
-                "ati" => ^jti,
+                "ati" => ^ati,
                 "exp" => _,
                 "iat" => _,
                 "iss" => "WatcherEx",
-                "jti" => _,
+                "jti" => jti,
                 "nbf" => _,
-                "typ" => ^typ
+                "typ" => ^typ,
+                "sub" => _
               }} = RefreshToken.verify_and_validate(refresh_token)
 
       assert %UserAttempt{username: ^username} = Repo.one(UserAttempt)
-      assert %Session{jti: ^jti} = Repo.one(Session)
+
+      assert [%Session{type: "access_token"}, %Session{jti: ^jti, type: "refresh_token"}] =
+               Repo.all(Session)
     end
 
     test "succeeds and generates a refresh_token validating totp" do
@@ -241,22 +244,25 @@ defmodule Authenticator.SignIn.Commands.ResourceOwnerTest do
                 token_type: typ
               }} = Command.execute(input)
 
-      assert {:ok, %{"jti" => jti}} = RefreshToken.verify_and_validate(access_token)
+      assert {:ok, %{"jti" => ati}} = RefreshToken.verify_and_validate(access_token)
 
       assert {:ok,
               %{
                 "aud" => ^client_id,
-                "ati" => ^jti,
+                "ati" => ^ati,
                 "exp" => _,
                 "iat" => _,
                 "iss" => "WatcherEx",
-                "jti" => _,
+                "jti" => jti,
                 "nbf" => _,
-                "typ" => ^typ
+                "typ" => ^typ,
+                "sub" => _
               }} = RefreshToken.verify_and_validate(refresh_token)
 
       assert %UserAttempt{username: ^username} = Repo.one(UserAttempt)
-      assert %Session{jti: ^jti} = Repo.one(Session)
+
+      assert [%Session{type: "access_token"}, %Session{jti: ^jti, type: "refresh_token"}] =
+               Repo.all(Session)
     end
 
     test "succeeds using client_assertions and generates an access_token" do

--- a/apps/authenticator/test/authenticator/sign_in/commands/resource_owner_test.exs
+++ b/apps/authenticator/test/authenticator/sign_in/commands/resource_owner_test.exs
@@ -378,7 +378,7 @@ defmodule Authenticator.SignIn.Commands.ResourceOwnerTest do
                client_id: ["can't be blank"],
                ip_address: ["can't be blank"],
                scope: ["can't be blank"]
-             } = errors_on(changeset)
+             } == errors_on(changeset)
 
       assert {:error, changeset} = Command.execute(%{"grant_type" => "password"})
 
@@ -390,7 +390,7 @@ defmodule Authenticator.SignIn.Commands.ResourceOwnerTest do
                client_id: ["can't be blank"],
                ip_address: ["can't be blank"],
                scope: ["can't be blank"]
-             } = errors_on(changeset)
+             } == errors_on(changeset)
     end
 
     test "fails if client application do not exist" do

--- a/apps/authenticator/test/authenticator/sign_out/commands/revoke_tokens_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/revoke_tokens_test.exs
@@ -1,0 +1,84 @@
+defmodule Authenticator.SignOut.Commands.RevokeTokensTest do
+  @moduledoc false
+
+  use Authenticator.DataCase, async: true
+
+  alias Authenticator.SignOut.Commands.Inputs.RevokeTokens, as: Input
+  alias Authenticator.SignOut.Commands.RevokeTokens, as: Commands
+
+  describe "#{Commands}.execute/1" do
+    setup do
+      scopes = RF.insert_list!(:scope, 3)
+      user = RF.insert!(:user)
+      app = RF.insert!(:client_application)
+      scope = scopes |> Enum.map(& &1.name) |> Enum.join(" ")
+
+      {:ok, user: user, app: app, scope: scope}
+    end
+
+    test "succeeds and invalidates access token", ctx do
+      access_token_claims = %{
+        "aud" => ctx.app.client_id,
+        "azp" => ctx.app.name,
+        "sub" => ctx.user.id,
+        "typ" => "Bearer",
+        "identity" => "user",
+        "scope" => ctx.scope
+      }
+
+      {:ok, access_token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
+
+      session =
+        insert!(
+          :session,
+          jti: jti,
+          subject_id: ctx.user.id,
+          subject_type: "user",
+          claims: claims
+        )
+
+      assert {:ok, {%{id: id, status: "revoked"}, nil}} =
+               Commands.execute(%Input{access_token: access_token})
+
+      assert session.id == id
+    end
+
+    test "fails if session not active", ctx do
+      access_token_claims = %{
+        "aud" => ctx.app.client_id,
+        "azp" => ctx.app.name,
+        "sub" => ctx.user.id,
+        "typ" => "Bearer",
+        "identity" => "user",
+        "scope" => ctx.scope
+      }
+
+      {:ok, access_token, %{"jti" => jti} = claims} = build_access_token(access_token_claims)
+
+      insert!(:session,
+        jti: jti,
+        subject_id: ctx.user.id,
+        subject_type: "user",
+        claims: claims,
+        status: "revoked"
+      )
+
+      assert {:error, :not_active} == Commands.execute(%Input{access_token: access_token})
+    end
+
+    test "fails if session not found", ctx do
+      access_token_claims = %{
+        "aud" => ctx.app.client_id,
+        "azp" => ctx.app.name,
+        "sub" => ctx.user.id,
+        "typ" => "Bearer",
+        "identity" => "user",
+        "scope" => ctx.scope
+      }
+
+      {:ok, access_token, _claims} = build_access_token(access_token_claims)
+
+      assert {:error, :not_found} == Commands.execute(%Input{access_token: access_token})
+    end
+  end
+end

--- a/apps/authenticator/test/authenticator/sign_out/commands/revoke_tokens_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/revoke_tokens_test.exs
@@ -78,7 +78,7 @@ defmodule Authenticator.SignOut.Commands.RevokeTokensTest do
 
       {:ok, access_token, _claims} = build_access_token(access_token_claims)
 
-      assert {:error, :not_found} == Commands.execute(%Input{access_token: access_token})
+      assert {:error, :anauthenticated} == Commands.execute(%Input{access_token: access_token})
     end
   end
 end

--- a/apps/authenticator/test/authenticator/sign_out/commands/sign_out_all_sessions_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/sign_out_all_sessions_test.exs
@@ -1,4 +1,4 @@
-defmodule Authenticator.SignIn.Commands.SignOutAllSessionsTest do
+defmodule Authenticator.SignOut.Commands.SignOutAllSessionsTest do
   @moduledoc false
 
   use Authenticator.DataCase, async: true

--- a/apps/authenticator/test/authenticator/sign_out/commands/sign_out_all_sessions_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/sign_out_all_sessions_test.exs
@@ -10,7 +10,7 @@ defmodule Authenticator.SignIn.Commands.SignOutAllSessionsTest do
     test "succeeds if session is valid" do
       session = insert!(:session)
       assert {:ok, 1} == Commands.execute(session.subject_id, session.subject_type)
-      assert %{status: "invalidated"} = Repo.get_by(Session, id: session.id)
+      assert %{status: "revoked"} = Repo.get_by(Session, id: session.id)
     end
 
     test "fails if not found any active session" do

--- a/apps/authenticator/test/authenticator/sign_out/commands/sign_out_session_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/sign_out_session_test.exs
@@ -8,18 +8,18 @@ defmodule Authenticator.SignIn.Commands.SignOutSessionTest do
   describe "#{Commands}.execute/1" do
     test "succeeds if session is valid" do
       session = insert!(:session)
-      assert {:ok, %{id: id, status: "invalidated"}} = Commands.execute(session)
+      assert {:ok, %{id: id, status: "revoked"}} = Commands.execute(session)
       assert session.id == id
     end
 
     test "succeeds if valid jti was passed and session active" do
       session = insert!(:session)
-      assert {:ok, %{id: id, status: "invalidated"}} = Commands.execute(session.jti)
+      assert {:ok, %{id: id, status: "revoked"}} = Commands.execute(session.jti)
       assert session.id == id
     end
 
     test "fails if session not active" do
-      session = insert!(:session, status: "invalidated")
+      session = insert!(:session, status: "revoked")
       assert {:error, :not_active} == Commands.execute(session.jti)
     end
 

--- a/apps/authenticator/test/authenticator/sign_out/commands/sign_out_session_test.exs
+++ b/apps/authenticator/test/authenticator/sign_out/commands/sign_out_session_test.exs
@@ -1,4 +1,4 @@
-defmodule Authenticator.SignIn.Commands.SignOutSessionTest do
+defmodule Authenticator.SignOut.Commands.SignOutSessionTest do
   @moduledoc false
 
   use Authenticator.DataCase, async: true

--- a/apps/authenticator/test/support/factory.ex
+++ b/apps/authenticator/test/support/factory.ex
@@ -13,6 +13,7 @@ defmodule Authenticator.Factory do
 
     %Session{
       jti: jti,
+      type: "access_token",
       subject_id: Ecto.UUID.generate(),
       subject_type: "user",
       claims: %{

--- a/apps/rest_api/lib/controllers/public/auth.ex
+++ b/apps/rest_api/lib/controllers/public/auth.ex
@@ -75,7 +75,7 @@ defmodule RestAPI.Controllers.Public.Auth do
   end
 
   @doc "Revoke the given tokens sessions"
-  @spec logout(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
+  @spec revoke(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
   def revoke(conn, params) do
     with {:ok, input} <- RevokeTokens.cast_and_apply(params),
          {:ok, _any} <- Commands.revoke_tokens(input) do

--- a/apps/rest_api/lib/controllers/public/auth.ex
+++ b/apps/rest_api/lib/controllers/public/auth.ex
@@ -10,8 +10,8 @@ defmodule RestAPI.Controllers.Public.Auth do
     ResourceOwner
   }
 
+  alias Authenticator.SignOut.Commands.Inputs.RevokeTokens
   alias Authorizer.Rules.Commands.Inputs.AuthorizationCodeSignIn
-
   alias RestAPI.Ports.{Authenticator, Authorizer}
   alias RestAPI.Views.Public.Auth
 
@@ -71,6 +71,15 @@ defmodule RestAPI.Controllers.Public.Auth do
       |> put_view(Auth)
       |> put_status(200)
       |> render("token.json", response: response)
+    end
+  end
+
+  @doc "Revoke the given tokens sessions"
+  @spec logout(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
+  def revoke(conn, params) do
+    with {:ok, input} <- RevokeTokens.cast_and_apply(params),
+         {:ok, _any} <- Commands.revoke_tokens(input) do
+      send_resp(conn, :ok, "")
     end
   end
 

--- a/apps/rest_api/lib/controllers/public/auth.ex
+++ b/apps/rest_api/lib/controllers/public/auth.ex
@@ -78,7 +78,7 @@ defmodule RestAPI.Controllers.Public.Auth do
   @spec revoke(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
   def revoke(conn, params) do
     with {:ok, input} <- RevokeTokens.cast_and_apply(params),
-         {:ok, _any} <- Commands.revoke_tokens(input) do
+         {:ok, _sessions} <- Authenticator.revoke_tokens(input) do
       send_resp(conn, :ok, "")
     end
   end

--- a/apps/rest_api/lib/ports/authenticator.ex
+++ b/apps/rest_api/lib/ports/authenticator.ex
@@ -20,22 +20,26 @@ defmodule RestAPI.Ports.Authenticator do
   @type possible_logout_failures :: {:error, Ecto.Changeset.t() | :not_found | :not_active}
 
   @doc "Delegates to Authenticator.sign_in_resource_owner/1"
-  @callback sign_in_resource_owner(input :: map()) :: possible_sign_in_responses()
+  @callback sign_in_resource_owner(input :: map() | struct()) :: possible_sign_in_responses()
 
   @doc "Delegates to Authenticator.sign_in_refresh_token/1"
-  @callback sign_in_refresh_token(input :: map()) :: possible_sign_in_responses()
+  @callback sign_in_refresh_token(input :: map() | struct()) :: possible_sign_in_responses()
 
   @doc "Delegates to Authenticator.sign_in_client_credentials/1"
-  @callback sign_in_client_credentials(input :: map()) :: possible_sign_in_responses()
+  @callback sign_in_client_credentials(input :: map() | struct()) :: possible_sign_in_responses()
 
   @doc "Delegates to Authenticator.sign_in_authorization_code/1"
-  @callback sign_in_authorization_code(input :: map()) :: possible_sign_in_responses()
+  @callback sign_in_authorization_code(input :: map() | struct()) :: possible_sign_in_responses()
 
   @doc "Delegates to Authenticator.get_session/1"
-  @callback get_session(input :: map()) :: struct()
+  @callback get_session(input :: map() | struct()) :: struct()
 
   @doc "Delegates to Authenticator.validate_access_token/1"
   @callback validate_access_token(token :: String.t()) :: {:ok, map()} | {:error, Keyword.t()}
+
+  @doc "Delegates to Authenticator.revoke_tokens/1"
+  @callback revoke_tokens(input :: map() | struct()) ::
+    {:ok, session :: struct()} | possible_logout_failures()
 
   @doc "Delegates to Authenticator.sign_out_session/1"
   @callback sign_out_session(session_or_jti :: struct() | String.t()) ::
@@ -71,6 +75,10 @@ defmodule RestAPI.Ports.Authenticator do
   @doc "Get's a session by the given input filters"
   @spec get_session(input :: map()) :: {:ok, struct()} | {:error, :not_found}
   def get_session(input), do: implementation().get_session(input)
+
+  @doc "Revoke the given token sessions"
+  @spec revoke_tokens(session_or_jti :: map()) :: {:ok, struct()} | possible_logout_failures()
+  def revoke_tokens(input), do: implementation().revoke_tokens(input)
 
   @doc "Invalidates a given session"
   @spec sign_out_session(session_or_jti :: map()) :: {:ok, struct()} | possible_logout_failures()

--- a/apps/rest_api/lib/ports/authenticator.ex
+++ b/apps/rest_api/lib/ports/authenticator.ex
@@ -39,7 +39,8 @@ defmodule RestAPI.Ports.Authenticator do
 
   @doc "Delegates to Authenticator.revoke_tokens/1"
   @callback revoke_tokens(input :: map() | struct()) ::
-    {:ok, session :: struct()} | possible_logout_failures()
+              {:ok, {access_session :: struct() | nil, refresh_session :: struct() | nil}}
+              | possible_logout_failures()
 
   @doc "Delegates to Authenticator.sign_out_session/1"
   @callback sign_out_session(session_or_jti :: struct() | String.t()) ::
@@ -77,7 +78,9 @@ defmodule RestAPI.Ports.Authenticator do
   def get_session(input), do: implementation().get_session(input)
 
   @doc "Revoke the given token sessions"
-  @spec revoke_tokens(session_or_jti :: map()) :: {:ok, struct()} | possible_logout_failures()
+  @spec revoke_tokens(input :: map()) ::
+          {:ok, {access_session :: struct() | nil, refresh_session :: struct() | nil}}
+          | possible_logout_failures()
   def revoke_tokens(input), do: implementation().revoke_tokens(input)
 
   @doc "Invalidates a given session"

--- a/apps/rest_api/lib/routers/public.ex
+++ b/apps/rest_api/lib/routers/public.ex
@@ -24,6 +24,7 @@ defmodule RestAPI.Routers.Public do
 
     scope "/auth/protocol/openid-connect" do
       post "/token", Auth, :token
+      post "/revoke", Auth, :revoke
 
       scope "/authorize" do
         pipe_through :authenticated


### PR DESCRIPTION
Add a new command for revoking access and refresh tokens.
In order to make this work i had to do some minor changes on all sign in flows for start creating refresh token sessions.