### PR TITLE
fix: token revoke validation

### DIFF
--- a/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
+++ b/apps/authenticator/lib/sign_out/commands/inputs/revoke_tokens.ex
@@ -18,5 +18,18 @@ defmodule Authenticator.SignOut.Commands.Inputs.RevokeTokens do
   end
 
   @doc false
-  def changeset(params) when is_map(params), do: cast(%__MODULE__{}, params, @optional)
+  def changeset(params) when is_map(params) do
+    %__MODULE__{}
+    |> cast(params, @optional)
+    |> validate_at_least_one_token_required()
+  end
+
+  defp validate_at_least_one_token_required(%Ecto.Changeset{changes: changes} = changeset)
+       when not is_map_key(changeset, :access_token) and not is_map_key(changes, :refresh_token) do
+    changeset
+    |> add_error(:access_token, "at least one token is required")
+    |> add_error(:refresh_token, "at least one token is required")
+  end
+
+  defp validate_at_least_one_token_required(changeset), do: changeset
 end

--- a/apps/rest_api/test/controllers/public/auth_test.exs
+++ b/apps/rest_api/test/controllers/public/auth_test.exs
@@ -382,8 +382,8 @@ defmodule RestAPI.Controllers.Public.AuthTest do
                "detail" => "The given params failed in validation",
                "error" => "bad_request",
                "response" => %{
-                 "access_token" => ["is invalid"],
-                 "refresh_token" => ["is invalid"]
+                 "access_token" => ["at least one token is required", "is invalid"],
+                 "refresh_token" => ["at least one token is required", "is invalid"]
                },
                "status" => 400
              } ==

--- a/apps/rest_api/test/controllers/public/auth_test.exs
+++ b/apps/rest_api/test/controllers/public/auth_test.exs
@@ -363,6 +363,15 @@ defmodule RestAPI.Controllers.Public.AuthTest do
              |> response(200)
     end
 
+    test "fails if access_token and refresh_token are not provided", %{conn: conn} do
+      params = %{}
+
+      assert conn
+             |> put_req_header("content-type", @content_type)
+             |> post(@revoke_endpoint, params)
+             |> response(400)
+    end
+
     test "fails if params are invalid", %{conn: conn} do
       params = %{
         "access_token" => 123,


### PR DESCRIPTION
If none of those inputs were given, the caller of the API could get the wrong impression thinking something has been done because it was returned a 200.

Added validation on RevokeTokens input so we give a proper response (400) if neither of the fields have been given.